### PR TITLE
Fixed not being able to return to 100 points in edge case

### DIFF
--- a/russ_clicker/backend/server.js
+++ b/russ_clicker/backend/server.js
@@ -257,16 +257,15 @@ app.get("/purchaseTenPoints/:username/:threshold", async (req, res) => {
     let currUser = await UserObj.findOne({ username: username });
     await currUser.populate("upgrades");
 
-    if (currUser.upgrades.ten != 1) {
-        currUser.score -= pointThreshold;
-        currUser.multiplier = 10;
-        await currUser.save();
-        currUser.upgrades.ten = 1;
-        await currUser.upgrades.save();
-        await currUser.save();
-    } else {
-        currUser.multiplier = 10;
-        await currUser.save();
+    if (currUser.upgrades.hundred != 1) {
+        if (currUser.upgrades.ten != 1) {
+            currUser.score -= pointThreshold;
+            currUser.multiplier = 10;
+            await currUser.save();
+            currUser.upgrades.ten = 1;
+            await currUser.upgrades.save();
+            await currUser.save();
+        }
     }
 
     res.setHeader('Content-Type', 'text/plain');

--- a/russ_clicker/frontend/public_html/game.css
+++ b/russ_clicker/frontend/public_html/game.css
@@ -101,7 +101,7 @@ button {
 }
 
 #popupButton {
-    margin-top: 70px;
+    margin-top: 50px;
     margin-left: auto;
     margin-right: auto;
     display: block;

--- a/russ_clicker/frontend/public_html/game.js
+++ b/russ_clicker/frontend/public_html/game.js
@@ -255,7 +255,7 @@ function purchaseOfflineHelper(purchaseThreshold) {
     requestObj.onreadystatechange = function () {
         if (this.readyState == XMLHttpRequest.DONE) {
             if (requestObj.status === 200) {
-                setPopup("Purchased");
+                setPopup("Purchased or already obtained");
             } else {
                 // something went wrong
                 console.log(requestObj.responseText);
@@ -305,7 +305,7 @@ function purchaseTenPointsHelper(purchaseThreshold) {
     requestObj.onreadystatechange = function () {
         if (this.readyState == XMLHttpRequest.DONE) {
             if (requestObj.status === 200) {
-                setPopup("Purchased");
+                setPopup("Purchased, surpassed, or already obtained");
             } else {
                 // something went wrong
                 console.log(requestObj.responseText);
@@ -356,7 +356,7 @@ function purchaseHundredPointsHelper(purchaseThreshold) {
     requestObj.onreadystatechange = function () {
         if (this.readyState == XMLHttpRequest.DONE) {
             if (requestObj.status === 200) {
-                setPopup("Purchased");
+                setPopup("Purchased or already obtained");
             } else {
                 // something went wrong
                 console.log(requestObj.responseText);


### PR DESCRIPTION
Fixed not being able to return to 100 points per click after purchasing 10 points per click. Now, if you have already purchased 100 points per click and you try to purchase 10 points per click, you are given a message stating that you have already surpassed 10 points per click.